### PR TITLE
Prepare for release

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,0 +1,48 @@
+
+name: GoRelease
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  GO_VERSION: '1.16'
+  TAG: ${{ github.ref_name }}
+  RELEASE_VERSION: ${{ github.ref_name }}
+defaults:
+  run:
+    working-directory: go/src/open-cluster-management.io/governance-policy-spec-sync
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: go/src/open-cluster-management.io/governance-policy-spec-sync
+      - name: install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: build images
+        run:  |
+          make build-images
+      - name: push image
+        run: |
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
+          docker push quay.io/open-cluster-management/governance-policy-spec-sync:$RELEASE_VERSION
+      - name: generate changelog
+        run: |
+          echo "# Governance-policy-spec-sync $RELEASE_VERSION" > /home/runner/work/changelog.txt
+          echo "- See the [CHANGELOG](https://github.com/open-cluster-management-io/governance-policy-spec-sync/blob/main/CHANGELOG/CHANGELOG-${RELEASE_VERSION}.md) for more details." >> /home/runner/work/changelog.txt
+          echo "- The released image is quay.io/open-cluster-management/governance-policy-spec-sync:$RELEASE_VERSION" >> /home/runner/work/changelog.txt
+      - name: publish release
+        uses: softprops/action-gh-release@v0.1.5
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          body_path: /home/runner/work/changelog.txt

--- a/CHANGELOG/CHANGELOG-v0.5.0.md
+++ b/CHANGELOG/CHANGELOG-v0.5.0.md
@@ -1,0 +1,1 @@
+# Initial release


### PR DESCRIPTION
The workflow and process has been tested on https://github.com/open-cluster-management-io/governance-policy-propagator, this just keeps these repos in line.