### PR TITLE
Allow syncing to an alternative namespace

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -74,6 +74,13 @@ jobs:
         export GOPATH=$(go env GOPATH)
         make e2e-test-coverage
 
+    - name: E2E Tests That Simulate Hosted Mode
+      run: |
+        export GOPATH=$(go env GOPATH)
+        export E2E_TARGET_NAMESPACE="other-namespace"
+        export COVERAGE_E2E_OUT=coverage_e2e_hosted_mode.out
+        make e2e-test-coverage
+
     - name: Test Coverage Verification
       if: ${{ github.event_name == 'pull_request' }}
       run: |

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ else
 endif
 # Test coverage threshold
 export COVERAGE_MIN ?= 70
+COVERAGE_E2E_OUT ?= coverage_e2e.out
 
 # Image URL to use all building/pushing image targets;
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.
@@ -295,7 +296,7 @@ e2e-build-instrumented:
 
 .PHONY: e2e-run-instrumented
 e2e-run-instrumented: e2e-build-instrumented
-	HUB_CONFIG=$(HUB_CONFIG) MANAGED_CONFIG=$(MANAGED_CONFIG) WATCH_NAMESPACE=$(WATCH_NAMESPACE) ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=coverage_e2e.out &>build/_output/controller.log &
+	HUB_CONFIG=$(HUB_CONFIG) MANAGED_CONFIG=$(MANAGED_CONFIG) WATCH_NAMESPACE=$(WATCH_NAMESPACE) ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=$(COVERAGE_E2E_OUT) &>build/_output/controller.log &
 
 .PHONY: e2e-stop-instrumented
 e2e-stop-instrumented:

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -14,7 +15,9 @@ import (
 // TestRunMain wraps the main() function in order to build a test binary and collection coverage for
 // E2E/Integration tests. Controller CLI flags are also passed in here.
 func TestRunMain(t *testing.T) {
-	os.Args = append(os.Args, "--leader-elect=false")
+	os.Args = append(
+		os.Args, "--leader-elect=false", fmt.Sprintf("--target-namespace=%s", os.Getenv("E2E_TARGET_NAMESPACE")),
+	)
 
 	main()
 }

--- a/test/e2e/case1_spec_sync_test.go
+++ b/test/e2e/case1_spec_sync_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Test spec sync", func() {
 			clientManagedDynamic,
 			gvrPolicy,
 			case1PolicyName,
-			testNamespace,
+			targetNamespace,
 			true,
 			defaultTimeoutSeconds)
 		Expect(plc).NotTo(BeNil())
@@ -45,7 +45,7 @@ var _ = Describe("Test spec sync", func() {
 			clientManagedDynamic,
 			gvrPolicy,
 			case1PolicyName,
-			testNamespace,
+			targetNamespace,
 			true,
 			defaultTimeoutSeconds)
 		Expect(plc).NotTo(BeNil())
@@ -72,7 +72,7 @@ var _ = Describe("Test spec sync", func() {
 				clientManagedDynamic,
 				gvrPolicy,
 				case1PolicyName,
-				testNamespace,
+				targetNamespace,
 				true,
 				defaultTimeoutSeconds)
 
@@ -99,7 +99,7 @@ var _ = Describe("Test spec sync", func() {
 				clientManagedDynamic,
 				gvrPolicy,
 				case1PolicyName,
-				testNamespace,
+				targetNamespace,
 				true,
 				defaultTimeoutSeconds)
 

--- a/test/e2e/case3_sync_secret_test.go
+++ b/test/e2e/case3_sync_secret_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Test spec sync", func() {
 			clientManagedDynamic,
 			gvrSecret,
 			secretsync.SecretName,
-			testNamespace,
+			targetNamespace,
 			true,
 			defaultTimeoutSeconds,
 		)
@@ -54,7 +54,7 @@ var _ = Describe("Test spec sync", func() {
 			clientManagedDynamic,
 			gvrSecret,
 			"not-the-policy-encryption-key",
-			testNamespace,
+			targetNamespace,
 			false,
 			defaultTimeoutSeconds,
 		)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -38,6 +38,7 @@ var (
 	kubeconfigHub         string
 	kubeconfigManaged     string
 	defaultTimeoutSeconds int
+	targetNamespace       string
 
 	defaultImageRegistry       string
 	defaultImagePullSecretName string
@@ -104,6 +105,21 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(namespacesHub.Get(context.TODO(), testNamespace, metav1.GetOptions{})).NotTo(BeNil())
 	Expect(clientManaged.CoreV1().Namespaces().Get(context.TODO(), testNamespace, metav1.GetOptions{})).NotTo(BeNil())
+
+	if os.Getenv("E2E_TARGET_NAMESPACE") != "" {
+		targetNamespace = os.Getenv("E2E_TARGET_NAMESPACE")
+
+		_, err := clientManaged.CoreV1().Namespaces().Create(
+			context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: targetNamespace}},
+			metav1.CreateOptions{},
+		)
+		if !errors.IsAlreadyExists(err) {
+			Expect(err).Should(BeNil())
+		}
+	} else {
+		targetNamespace = testNamespace
+	}
 })
 
 func NewKubeClient(url, kubeconfig, context string) kubernetes.Interface {

--- a/tool/options.go
+++ b/tool/options.go
@@ -20,6 +20,9 @@ type PolicySpecSyncOptions struct {
 	ManagedConfigFilePathName string
 	LegacyLeaderElection      bool
 	ProbeAddr                 string
+	// The namespace that the replicated policies should be synced to. This defaults to the same namespace as on the
+	// Hub.
+	TargetNamespace string
 }
 
 // Options default value
@@ -77,6 +80,14 @@ func ProcessFlags() {
 		"health-probe-bind-address",
 		":8081",
 		"The address the probe endpoint binds to.",
+	)
+
+	flag.StringVar(
+		&Options.TargetNamespace,
+		"target-namespace",
+		"",
+		"The namespace that the replicated policies should be synced to. This defaults to the same namespace as on "+
+			"the Hub",
 	)
 }
 


### PR DESCRIPTION
This is required for running the Policy addon in hosted mode because the
namespace on the hosting cluster might be different than the cluster
name.

Relates:
https://github.com/stolostron/backlog/issues/24362